### PR TITLE
It's not appropriate to use js syntax in ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -305,4 +305,3 @@ namespace Avatar {
 }
 
 export default Avatar;
-module.exports = Avatar;


### PR DESCRIPTION
When we want to import avatar like this:
```
import Avatar from 'avatar-builder'
```
It becomes undefined. and made us to use:
```
import * as Avatar from 'avatar-builder'
```

but with this proposal, we don't have any problem. we can use `import Avatar from 'avatar-builder'` without any problem.